### PR TITLE
updating galaxy.yml

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -2,10 +2,10 @@
 # The namespace of the collection. This can be a company/brand/organization or product namespace under which all
 # content lives. May only contain alphanumeric lowercase characters and underscores. Namespaces cannot start with
 # underscores or numbers and cannot contain consecutive underscores
-namespace: redhat
+namespace: sap
 
 # The name of the collection. Has the same character restrictions as 'namespace'
-name: sap_operations
+name: operations
 
 # The version of the collection. Must be compatible with semantic versioning
 version: 1.0.0
@@ -33,7 +33,9 @@ license_file: ''
 
 # A list of tags you want to associate with the collection for indexing/searching. A tag name has the same character
 # requirements as 'namespace' and 'name'
-tags: [sap]
+tags: 
+  - linux
+  - sap
 
 # Collections that this collection requires to be installed for it to be usable. The key of the dict is the
 # collection label 'namespace.name'. The value is a version range


### PR DESCRIPTION
this update changes the namespace (as it will be going downstream into the sap namespace) and also adjusts its name (changed purely to remove name repetition). 

also added a tag from the required list on AH to get past the tag check on AH importer. 

sanity passed locally and collection has all other requirements met, once this merged (or you all add it in), we should be good to release. 